### PR TITLE
feat: skip OAuth1 browser flow when access tokens are pre-configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,17 @@ allowlist.
 
 ## OAuth1 flow (startup behavior)
 
-On startup, the server opens a browser for OAuth1 consent and waits for the
-callback. Tokens are kept in memory only for the lifetime of the server
-process. Set `X_OAUTH_PRINT_TOKENS=1` to print tokens, or
+On startup, the server needs OAuth1 access tokens to sign requests.
+
+**Non-interactive mode (headless / CI):** Set `X_OAUTH_ACCESS_TOKEN` and
+`X_OAUTH_ACCESS_TOKEN_SECRET` in your `.env`. When both are present, the
+server skips the browser flow and uses them directly.
+
+**Interactive mode (default):** If the access token env vars are empty, the
+server opens a browser for OAuth1 consent and waits for the callback. Tokens
+are kept in memory only for the lifetime of the server process.
+
+Set `X_OAUTH_PRINT_TOKENS=1` to print tokens, or
 `X_OAUTH_PRINT_AUTH_HEADER=1` to print request headers.
 
 ## Available tool calls (allowlist-ready)

--- a/server.py
+++ b/server.py
@@ -314,7 +314,12 @@ def build_oauth1_client() -> OAuth1Client:
         raise RuntimeError(
             "Missing X_OAUTH_CONSUMER_KEY or X_OAUTH_CONSUMER_SECRET for OAuth1 signing."
         )
-    access_token, access_secret = run_oauth1_flow()
+    access_token = os.getenv("X_OAUTH_ACCESS_TOKEN", "").strip()
+    access_secret = os.getenv("X_OAUTH_ACCESS_TOKEN_SECRET", "").strip()
+    if access_token and access_secret:
+        OAUTH_LOGGER.info("Using pre-configured OAuth1 access tokens.")
+    else:
+        access_token, access_secret = run_oauth1_flow()
     if is_truthy(os.getenv("X_OAUTH_PRINT_TOKENS", "0")):
         print("OAuth1 access token:", access_token)
         print("OAuth1 access token secret:", access_secret)


### PR DESCRIPTION
## Summary

When `X_OAUTH_ACCESS_TOKEN` and `X_OAUTH_ACCESS_TOKEN_SECRET` are both set
in the environment, `build_oauth1_client()` now uses them directly instead
of opening a browser for the interactive OAuth1 consent flow.

## Problem

The server always runs the interactive OAuth1 flow on startup
(`server.py:317`), which opens a browser window. This makes it impossible
to run the server in headless environments (containers, CI, remote servers,
MCP clients that can't open a browser). The env vars for pre-configured
tokens already exist in `env.example` (lines 30-31) but were never read by
`build_oauth1_client()`.

## Changes

- `server.py`: `build_oauth1_client()` checks `X_OAUTH_ACCESS_TOKEN` and
  `X_OAUTH_ACCESS_TOKEN_SECRET` before calling `run_oauth1_flow()`. If both
  are set, the browser flow is skipped.
- `README.md`: Updated the "OAuth1 flow" section to document both
  interactive and non-interactive modes.

## Testing

The change is a 5-line conditional guard in `build_oauth1_client()`. When
the env vars are empty (existing behavior), `run_oauth1_flow()` runs as
before. When set, the function skips straight to building the `OAuth1Client`
with the provided tokens.

This contribution was developed with AI assistance (Claude Code).