### PR TITLE
feat: skip OAuth1 browser flow when tokens are provided via env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY server.py .
+
+ENV MCP_HOST=0.0.0.0
+EXPOSE 8000
+
+CMD ["python", "server.py"]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ FastMCP. Streaming and webhook endpoints are excluded.
 - An X Developer Platform app (to get tokens)
 - Optional: an xAI API key if you want to run the Grok test client
 
+## Setup (Docker)
+
+```bash
+docker build -t xmcp .
+docker run --env-file .env -p 8000:8000 xmcp
+```
+
+Set `MCP_TRANSPORT=sse` in `.env` to serve SSE at `/sse` instead of
+Streamable HTTP at `/mcp`.
+
 ## Setup (local)
 
 1. Create a virtual environment and install dependencies:
@@ -31,6 +41,7 @@ FastMCP. Streaming and webhook endpoints are excluded.
      - `X_API_TIMEOUT` (default `30`)
      - `MCP_HOST` (default `127.0.0.1`)
      - `MCP_PORT` (default `8000`)
+     - `MCP_TRANSPORT` (default `http`; set to `sse` for SSE transport)
      - `X_API_DEBUG` (default `1`)
   - Tool filtering (optional, comma-separated):
     - `X_API_TOOL_ALLOWLIST`

--- a/README.md
+++ b/README.md
@@ -89,6 +89,20 @@ callback. Tokens are kept in memory only for the lifetime of the server
 process. Set `X_OAUTH_PRINT_TOKENS=1` to print tokens, or
 `X_OAUTH_PRINT_AUTH_HEADER=1` to print request headers.
 
+### Reusing OAuth1 tokens (headless / Docker)
+
+To skip the browser flow on subsequent startups, set both
+`X_OAUTH_ACCESS_TOKEN` and `X_OAUTH_ACCESS_TOKEN_SECRET` in your `.env`.
+When both are present the server uses them directly and never opens a browser.
+
+1. Run once with `X_OAUTH_PRINT_TOKENS=1`, complete the browser flow.
+2. Copy the printed tokens into `.env`:
+   ```
+   X_OAUTH_ACCESS_TOKEN=<token>
+   X_OAUTH_ACCESS_TOKEN_SECRET=<secret>
+   ```
+3. Restart the server — no browser needed.
+
 ## Available tool calls (allowlist-ready)
 
 Below is the full list of tool calls you can whitelist via

--- a/server.py
+++ b/server.py
@@ -314,10 +314,18 @@ def build_oauth1_client() -> OAuth1Client:
         raise RuntimeError(
             "Missing X_OAUTH_CONSUMER_KEY or X_OAUTH_CONSUMER_SECRET for OAuth1 signing."
         )
-    access_token, access_secret = run_oauth1_flow()
-    if is_truthy(os.getenv("X_OAUTH_PRINT_TOKENS", "0")):
-        print("OAuth1 access token:", access_token)
-        print("OAuth1 access token secret:", access_secret)
+    access_token = os.getenv("X_OAUTH_ACCESS_TOKEN", "").strip()
+    access_secret = os.getenv("X_OAUTH_ACCESS_TOKEN_SECRET", "").strip()
+
+    if access_token and access_secret:
+        OAUTH_LOGGER.info(
+            "Using existing OAuth1 tokens from environment, skipping browser flow."
+        )
+    else:
+        access_token, access_secret = run_oauth1_flow()
+        if is_truthy(os.getenv("X_OAUTH_PRINT_TOKENS", "0")):
+            print("OAuth1 access token:", access_token)
+            print("OAuth1 access token secret:", access_secret)
     LOGGER.info("OAuth1 access token: %s", access_token)
     return OAuth1Client(
         client_key=consumer_key,

--- a/server.py
+++ b/server.py
@@ -468,8 +468,9 @@ def create_mcp() -> FastMCP:
 def main() -> None:
     host = os.getenv("MCP_HOST", "127.0.0.1")
     port = int(os.getenv("MCP_PORT", "8000"))
+    transport = os.getenv("MCP_TRANSPORT", "http")
     mcp = create_mcp()
-    mcp.run(transport="http", host=host, port=port)
+    mcp.run(transport=transport, host=host, port=port)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- When `X_OAUTH_ACCESS_TOKEN` and `X_OAUTH_ACCESS_TOKEN_SECRET` are both set in `.env`, `build_oauth1_client()` reuses them directly and skips `run_oauth1_flow()` entirely.
- This enables headless and Docker deployments without requiring an interactive browser session on every startup.
- Added a "Reusing OAuth1 tokens" section to README documenting the workflow: run once with `X_OAUTH_PRINT_TOKENS=1`, save the tokens, then restart without a browser.

## Test plan

- [ ] Start server **without** `X_OAUTH_ACCESS_TOKEN` / `X_OAUTH_ACCESS_TOKEN_SECRET` → browser OAuth1 flow should work as before
- [ ] Start server **with** both env vars set → should skip browser flow and log "Using existing OAuth1 tokens from environment"
- [ ] Verify API calls succeed with reused tokens (e.g. `getUsersMe`)


Made with [Cursor](https://cursor.com)