### PR TITLE
feat: add MCP_TRANSPORT=stdio support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ FastMCP. Streaming and webhook endpoints are excluded.
    - Server settings (optional):
      - `X_API_BASE_URL` (default `https://api.x.com`)
      - `X_API_TIMEOUT` (default `30`)
-     - `MCP_HOST` (default `127.0.0.1`)
-     - `MCP_PORT` (default `8000`)
+     - `MCP_TRANSPORT` (default `http`; set to `stdio` when launched by a local MCP client)
+     - `MCP_HOST` (default `127.0.0.1`; ignored in stdio mode)
+     - `MCP_PORT` (default `8000`; ignored in stdio mode)
      - `X_API_DEBUG` (default `1`)
   - Tool filtering (optional, comma-separated):
     - `X_API_TOOL_ALLOWLIST`
@@ -67,7 +68,10 @@ python server.py
 The MCP endpoint is `http://127.0.0.1:8000/mcp` by default.
 
 5. Connect an MCP client:
-- Local client: point it to `http://127.0.0.1:8000/mcp`.
+- Local HTTP client: point it to `http://127.0.0.1:8000/mcp`.
+- Local stdio client (Claude Code, Claude Desktop, etc.): set `MCP_TRANSPORT=stdio`
+  in `.env` and have the client spawn `python server.py` directly — the server
+  will speak JSON-RPC over stdin/stdout and ignore `MCP_HOST`/`MCP_PORT`.
 - Remote client: tunnel your local server (e.g., ngrok) and use the public URL.
 
 ## Whitelisting tools

--- a/env.example
+++ b/env.example
@@ -15,6 +15,11 @@ X_API_TIMEOUT=30
 X_API_DEBUG=1
 
 # MCP server settings
+# MCP_TRANSPORT: "http" (default) exposes the server over HTTP on MCP_HOST:MCP_PORT.
+# Set to "stdio" when the server is launched by a local MCP client (Claude Code,
+# Claude Desktop, etc.) that speaks JSON-RPC over stdin/stdout. In stdio mode,
+# MCP_HOST and MCP_PORT are ignored.
+MCP_TRANSPORT=http
 MCP_HOST=127.0.0.1
 MCP_PORT=8000
 

--- a/server.py
+++ b/server.py
@@ -452,9 +452,18 @@ def create_mcp() -> FastMCP:
 
 
 def main() -> None:
+    # create_mcp() loads .env, so read transport/host/port after it to respect .env overrides.
+    mcp = create_mcp()
+    transport = os.getenv("MCP_TRANSPORT", "http").strip().lower()
+    if transport == "stdio":
+        mcp.run(transport="stdio")
+        return
+    if transport != "http":
+        raise RuntimeError(
+            f"Unsupported MCP_TRANSPORT={transport!r}. Use 'http' or 'stdio'."
+        )
     host = os.getenv("MCP_HOST", "127.0.0.1")
     port = int(os.getenv("MCP_PORT", "8000"))
-    mcp = create_mcp()
     mcp.run(transport="http", host=host, port=port)
 
 


### PR DESCRIPTION
## Summary

Expose `MCP_TRANSPORT` as an environment variable with values `http` (default, unchanged behavior) or `stdio`.

## Problem

Local MCP clients that spawn servers as child processes and speak JSON-RPC over stdin/stdout — Claude Code, Claude Desktop, and others — cannot connect to the current server without an HTTP shim. `main()` hardcodes `mcp.run(transport="http", ...)` on every startup.

FastMCP natively supports a `stdio` transport; this just wires it through an env var.

## Changes

- `server.py`: `main()` now reads `MCP_TRANSPORT` (default `http`) after `create_mcp()` and dispatches to `mcp.run(transport="stdio")` or `mcp.run(transport="http", ...)`. Unknown values raise a clear `RuntimeError` instead of falling back silently.
- `env.example`: new `MCP_TRANSPORT=http` with a comment describing when to switch to `stdio`.
- `README.md`: documents the new variable under Server settings and splits the "Connect an MCP client" section to cover HTTP, stdio, and remote clients.

## Side effect: env-loading order

`create_mcp()` calls `load_env()` internally. Previously `MCP_HOST` / `MCP_PORT` were read *before* `create_mcp()`, so values set in `.env` were ignored (process-env only). Moving `create_mcp()` first makes `.env` overrides work for those two variables as well, which touches the same ordering concern raised in #8.

## Testing

- Default (`MCP_TRANSPORT` unset or `http`): unchanged — server listens on `MCP_HOST:MCP_PORT`.
- `MCP_TRANSPORT=stdio`: client sends `initialize` + `notifications/initialized` + `tools/list` over stdin; server returns the full tool list over stdout (verified locally, 131 tools returned).
- `MCP_TRANSPORT=<invalid>`: raises `RuntimeError("Unsupported MCP_TRANSPORT=...")` at startup.

This contribution was developed with AI assistance (Claude Code).