### PR TITLE
Skip OAuth1 browser flow when access tokens are pre-provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,19 @@ callback. Tokens are kept in memory only for the lifetime of the server
 process. Set `X_OAUTH_PRINT_TOKENS=1` to print tokens, or
 `X_OAUTH_PRINT_AUTH_HEADER=1` to print request headers.
 
+### Skipping the browser flow (for headless / hosted deploys)
+
+The interactive browser flow is unsuitable for non-interactive environments
+such as CI builds or hosted MCP runtimes (no display, no user, no inbound
+localhost callback). To skip it, run the flow once locally with
+`X_OAUTH_PRINT_TOKENS=1` to capture both tokens, then provide them via env:
+
+- `X_OAUTH_ACCESS_TOKEN`
+- `X_OAUTH_ACCESS_TOKEN_SECRET`
+
+When both are set, `build_oauth1_client` uses them directly and does not open
+a browser or contact `/oauth/request_token`.
+
 ## Available tool calls (allowlist-ready)
 
 Below is the full list of tool calls you can whitelist via

--- a/server.py
+++ b/server.py
@@ -307,7 +307,10 @@ def build_oauth1_client() -> OAuth1Client:
         raise RuntimeError(
             "Missing X_OAUTH_CONSUMER_KEY or X_OAUTH_CONSUMER_SECRET for OAuth1 signing."
         )
-    access_token, access_secret = run_oauth1_flow()
+    access_token = os.getenv("X_OAUTH_ACCESS_TOKEN")
+    access_secret = os.getenv("X_OAUTH_ACCESS_TOKEN_SECRET")
+    if not (access_token and access_secret):
+        access_token, access_secret = run_oauth1_flow()
     if is_truthy(os.getenv("X_OAUTH_PRINT_TOKENS", "0")):
         print("OAuth1 access token:", access_token)
         print("OAuth1 access token secret:", access_secret)


### PR DESCRIPTION
## Summary

`build_oauth1_client` unconditionally calls `run_oauth1_flow()`, which opens a browser via `webbrowser.open` and binds a localhost listener on `127.0.0.1:8976` to receive the OAuth1 callback. This is a desktop flow and cannot run in non-interactive environments — CI builds, hosted MCP runtimes (e.g. FastMCP Cloud / Horizon), or anything without a display and an in-process browser on the same machine.

This PR adds an env-var path: when **both** `X_OAUTH_ACCESS_TOKEN` and `X_OAUTH_ACCESS_TOKEN_SECRET` are set, use them directly and skip the browser flow. Local behaviour is unchanged when either env var is unset — the interactive flow still runs exactly as before.

## Why this matters

Trying to deploy xmcp to FastMCP Cloud / Horizon currently fails during the `fastmcp inspect` build step because importing `server.py` triggers `create_mcp() → build_oauth1_client() → run_oauth1_flow()`, which:

1. Calls `/oauth/request_token` with `oauth_callback=http://127.0.0.1:8976/oauth/callback` — X rejects with error 415 *Callback URL not approved* unless the user registers a localhost callback (which is itself unworkable in a hosted container anyway).
2. Even if registration succeeded, `_wait_for_callback` would block for 300s and time out, since the build container has no browser, no display, and no inbound localhost path from the user's machine.

After this change, hosting the server is straightforward: complete the OAuth1 dance once locally with `X_OAUTH_PRINT_TOKENS=1`, capture both values, and set them on the host. No code branching at the call sites; same `OAuth1Client` instance is returned either way.

## Doc/runtime mismatch fixed as a side effect

The README already mentioned `X_OAUTH_ACCESS_TOKEN` as a way to supply a pre-generated token (see the *Generate an OAuth2 user token (optional)* section), but the runtime never actually consumed it — it was only read by `get_auth_headers`, which the request-signing path (`sign_oauth1_request` httpx event hook) does not use. After this PR, the env var is honoured at the place it logically belongs: in `build_oauth1_client`.

## Changes

- `server.py`: read `X_OAUTH_ACCESS_TOKEN` / `X_OAUTH_ACCESS_TOKEN_SECRET` first; only fall back to `run_oauth1_flow()` when either is missing.
- `README.md`: new subsection *Skipping the browser flow (for headless / hosted deploys)* documenting the workflow.

## Test plan

- [x] `python -m py_compile server.py` passes
- [x] Local run without the new env vars: unchanged — browser opens, OAuth1 flow completes
- [ ] Local run with both env vars set (using tokens captured from a prior run): server starts without opening a browser, signs and sends API requests successfully
- [ ] Hosted run on FastMCP Cloud (Horizon): `fastmcp inspect` succeeds during build, server starts and serves `/mcp` over the platform-provided HTTPS URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)