### PR TITLE
Fix News schema validation for searchNews

### DIFF
--- a/server.py
+++ b/server.py
@@ -235,6 +235,7 @@ def should_exclude_operation(path: str, operation: dict) -> bool:
 
 def filter_openapi_spec(spec: dict) -> dict:
     filtered = copy.deepcopy(spec)
+    normalize_known_spec_mismatches(filtered)
     paths = filtered.get("paths", {})
     new_paths = {}
     allow_tags = {tag.lower() for tag in parse_csv_env("X_API_TOOL_TAGS")}
@@ -269,6 +270,25 @@ def filter_openapi_spec(spec: dict) -> dict:
 
     filtered["paths"] = new_paths
     return filtered
+
+
+def normalize_known_spec_mismatches(spec: dict) -> None:
+    schemas = spec.get("components", {}).get("schemas", {})
+    news = schemas.get("News")
+    if not isinstance(news, dict):
+        return
+
+    required = news.get("required")
+    if isinstance(required, list) and "rest_id" in required:
+        required = [field for field in required if field != "rest_id"]
+        if required:
+            news["required"] = required
+        else:
+            news.pop("required", None)
+
+    properties = news.get("properties")
+    if isinstance(properties, dict) and "id" not in properties and "rest_id" in properties:
+        properties["id"] = copy.deepcopy(properties["rest_id"])
 
 
 def print_tool_list(spec: dict) -> None:

--- a/test_server.py
+++ b/test_server.py
@@ -1,0 +1,52 @@
+import unittest
+
+import server
+
+
+class NormalizeKnownSpecMismatchesTest(unittest.TestCase):
+    def test_news_rest_id_is_not_required_and_id_is_accepted(self) -> None:
+        spec = {
+            "components": {
+                "schemas": {
+                    "News": {
+                        "required": ["rest_id"],
+                        "properties": {
+                            "rest_id": {"type": "string"},
+                        },
+                    },
+                },
+            },
+        }
+
+        server.normalize_known_spec_mismatches(spec)
+
+        news = spec["components"]["schemas"]["News"]
+        self.assertNotIn("required", news)
+        self.assertEqual(news["properties"]["id"], {"type": "string"})
+        self.assertEqual(news["properties"]["rest_id"], {"type": "string"})
+
+    def test_news_normalization_preserves_other_required_fields(self) -> None:
+        spec = {
+            "components": {
+                "schemas": {
+                    "News": {
+                        "required": ["rest_id", "name"],
+                        "properties": {
+                            "id": {"type": "string"},
+                            "rest_id": {"type": "string"},
+                            "name": {"type": "string"},
+                        },
+                    },
+                },
+            },
+        }
+
+        server.normalize_known_spec_mismatches(spec)
+
+        news = spec["components"]["schemas"]["News"]
+        self.assertEqual(news["required"], ["name"])
+        self.assertEqual(news["properties"]["id"], {"type": "string"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Normalize the live OpenAPI `News` schema before FastMCP tool generation.
- Remove `rest_id` from the required fields for `News` when present.
- Add `id` as an accepted `News` property when the schema only exposes `rest_id`.
- Add a small unit test for the News schema normalization behavior.

## Why

`searchNews` can fail output validation because the hosted OpenAPI spec declares `News.required = ["rest_id"]`, while `news.fields` exposes `id` and live `/2/news/search` responses include `id` without `rest_id`.

This keeps XMCP usable while the hosted OpenAPI schema and live News response shape differ.

## Validation

- Ran `git diff --check`.
- Ran `python -m unittest test_server.py`.
- Parsed `server.py` with `ast.parse`.
- Exercised `normalize_known_spec_mismatches` on a minimal `News` schema.
- Loaded the hosted OpenAPI spec and verified the filtered `News` schema has no required `rest_id` and includes `id`.
