### PR TITLE
Avoid logging OAuth1 access tokens

### DIFF
--- a/server.py
+++ b/server.py
@@ -311,7 +311,7 @@ def build_oauth1_client() -> OAuth1Client:
     if is_truthy(os.getenv("X_OAUTH_PRINT_TOKENS", "0")):
         print("OAuth1 access token:", access_token)
         print("OAuth1 access token secret:", access_secret)
-    LOGGER.info("OAuth1 access token: %s", access_token)
+    LOGGER.info("OAuth1 access token acquired.")
     return OAuth1Client(
         client_key=consumer_key,
         client_secret=consumer_secret,


### PR DESCRIPTION
## Summary

Stop logging the OAuth1 access token value at INFO level after the browser OAuth flow completes.

## Why

The existing log line persists a long-lived credential in normal logs for users who run the server under log redirection, containers, process supervisors, or hosted logging pipelines. The token is only needed to construct the OAuth1 client and does not need to be emitted for normal diagnostics.

Fixes #12.

## Validation

- `python3 -c 'compile(open("server.py", encoding="utf-8").read(), "server.py", "exec")'`
- `git diff --check`
