### PR TITLE
Support the MCP 2026-07-28 specification ("MCP 2.0")

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,14 @@
 Run a local MCP server that exposes the X API OpenAPI spec as tools using
 FastMCP. Streaming and webhook endpoints are excluded.
 
+Speaks the [`2026-07-28`](https://modelcontextprotocol.io/specification/2026-07-28/)
+MCP specification (the "MCP 2.0" revision) and still serves handshake-era
+clients on `2025-11-25` and earlier from the same endpoint. See
+[MCP protocol version](#mcp-protocol-version).
+
 ## Prerequisites
 
-- Python 3.9+
+- Python 3.10+ (required by FastMCP 4)
 - An X Developer Platform app (to get tokens)
 - Optional: an xAI API key if you want to run the Grok test client
 
@@ -31,6 +36,7 @@ FastMCP. Streaming and webhook endpoints are excluded.
      - `X_API_TIMEOUT` (default `30`)
      - `MCP_HOST` (default `127.0.0.1`)
      - `MCP_PORT` (default `8000`)
+     - `MCP_CACHE_TTL` (default `300`; seconds, `0` disables)
      - `X_API_DEBUG` (default `1`)
   - Tool filtering (optional, comma-separated):
     - `X_API_TOOL_ALLOWLIST`
@@ -69,6 +75,40 @@ The MCP endpoint is `http://127.0.0.1:8000/mcp` by default.
 5. Connect an MCP client:
 - Local client: point it to `http://127.0.0.1:8000/mcp`.
 - Remote client: tunnel your local server (e.g., ngrok) and use the public URL.
+
+## MCP protocol version
+
+The server implements the `2026-07-28` MCP specification, the revision the SDKs
+ship as their 2.0 major release. What that means here:
+
+- **Stateless.** There is no `initialize`/`initialized` handshake and no
+  `Mcp-Session-Id`. Every request carries its own protocol version, client
+  identity, and capabilities in `_meta`, so requests can be load balanced
+  round-robin across processes.
+- **Discovery.** `server/discover` returns the supported versions, capabilities,
+  and server identity in one request, with no prior handshake.
+- **Cacheable listings.** The tool set is derived from the OpenAPI spec once at
+  startup and is immutable for the life of the process, so `tools/list` and
+  `server/discover` carry a `ttlMs`/`cacheScope` hint. Tune it with
+  `MCP_CACHE_TTL` (seconds); `MCP_CACHE_TTL=0` leaves the protocol default of
+  `ttlMs: 0`, which tells clients the result is immediately stale. The hint is
+  only honored by `2026-07-28` clients that opt into caching.
+- **Backward compatible.** The same `/mcp` endpoint still serves clients that
+  use the older `initialize` handshake, including xAI's hosted MCP client used
+  by `test_grok_mcp.py`. No separate deployment is needed.
+
+Deprecated MCP features are not used by this server: it has no roots or
+sampling, and it logs to stderr through Python's `logging` rather than the
+deprecated MCP logging capability.
+
+Authorization to the MCP endpoint itself is unchanged — the server is meant to
+run locally and holds the X credentials itself, so the spec's authorization
+hardening (issuer validation, Client ID Metadata Documents) does not apply.
+If you expose this server publicly, put an authorizing proxy in front of it.
+
+FastMCP 4 is currently a beta (`4.0.0b1`); it is the first release that
+implements `2026-07-28`. `pip install -r requirements.txt` picks it up without
+`--pre` because the pin names the prerelease explicitly.
 
 ## Whitelisting tools
 
@@ -236,5 +276,5 @@ Below is the full list of tool calls you can whitelist via
 - Endpoints with `/stream` or `/webhooks` in the path are excluded.
 - Operations tagged `Stream` or `Webhooks`, or marked with
   `x-twitter-streaming: true`, are excluded.
-- The OpenAPI spec is fetched from `https://api.twitter.com/2/openapi.json` at
+- The OpenAPI spec is fetched from `https://api.x.com/2/openapi.json` at
   startup.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ Below is the full list of tool calls you can whitelist via
 - `createMediaSubtitles`
 - `createPosts`
 - `createUsersBookmark`
-- `deleteActivitySubscription`
 - `deleteAllConnections`
 - `deleteCommunityNotes`
 - `deleteConnectionsByEndpoint`
@@ -162,8 +161,6 @@ Below is the full list of tool calls you can whitelist via
 - `finalizeMediaUpload`
 - `followList`
 - `followUser`
-- `getAccountActivitySubscriptionCount`
-- `getActivitySubscriptions`
 - `getChatConversation`
 - `getChatConversations`
 - `getCommunitiesById`
@@ -251,7 +248,6 @@ Below is the full list of tool calls you can whitelist via
 - `unmuteUser`
 - `unpinList`
 - `unrepostPost`
-- `updateActivitySubscription`
 - `updateLists`
 
 ## Generate an OAuth2 user token (optional)
@@ -273,8 +269,11 @@ Below is the full list of tool calls you can whitelist via
 
 ## Notes
 
-- Endpoints with `/stream` or `/webhooks` in the path are excluded.
-- Operations tagged `Stream` or `Webhooks`, or marked with
-  `x-twitter-streaming: true`, are excluded.
+- Endpoints with `/stream`, `/webhooks`, `/account_activity`, or
+  `/activity/subscriptions` in the path are excluded.
+- Operations tagged `Stream`, `Webhooks`, `Activity`, or `Account Activity`, or
+  marked with `x-twitter-streaming: true`, are excluded. The activity
+  subscription endpoints configure webhook delivery, and most of them sit
+  outside the `/webhooks` path prefix.
 - The OpenAPI spec is fetched from `https://api.x.com/2/openapi.json` at
   startup.

--- a/env.example
+++ b/env.example
@@ -17,6 +17,9 @@ X_API_DEBUG=1
 # MCP server settings
 MCP_HOST=127.0.0.1
 MCP_PORT=8000
+# Cache hint (seconds) sent to MCP 2026-07-28 clients on tools/list and
+# server/discover. Set to 0 to tell clients not to cache.
+MCP_CACHE_TTL=300
 
 # Tool filtering (optional, comma-separated)
 X_API_TOOL_ALLOWLIST=

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-fastmcp
-httpx
+fastmcp>=4.0.0b1
+httpx2>=2.5.0
 python-dotenv
 requests-oauthlib
 xai-sdk

--- a/server.py
+++ b/server.py
@@ -225,8 +225,16 @@ def should_exclude_operation(path: str, operation: dict) -> bool:
     if "/webhooks" in path or "/stream" in path:
         return True
 
+    # Activity subscriptions configure where X pushes webhook events rather
+    # than reading or writing content, and most of them sit outside the
+    # /webhooks prefix that the check above catches.
+    if "/account_activity" in path or "/activity/subscriptions" in path:
+        return True
+
     tags = [tag.lower() for tag in operation.get("tags", []) if isinstance(tag, str)]
     if "stream" in tags or "webhooks" in tags:
+        return True
+    if "activity" in tags or "account activity" in tags:
         return True
 
     if operation.get("x-twitter-streaming") is True:

--- a/server.py
+++ b/server.py
@@ -388,8 +388,26 @@ def create_mcp() -> FastMCP:
 
     b3_flags = os.getenv("X_B3_FLAGS", "1")
 
+    # Endpoints that only accept OAuth 2.0 App-Only (Bearer), not OAuth1 user context
+    APP_ONLY_PATH_PREFIXES = (
+        "/2/trends/by/woeid",
+    )
+
+    bearer_token = os.getenv("X_BEARER_TOKEN", "").strip()
+
     async def sign_oauth1_request(request: httpx.Request) -> None:
         request.headers["X-B3-Flags"] = b3_flags
+
+        # App-Only endpoints: use Bearer, skip OAuth1 signing
+        if request.url.path.startswith(APP_ONLY_PATH_PREFIXES):
+            if not bearer_token:
+                raise RuntimeError(
+                    "X_BEARER_TOKEN required for App-Only endpoint "
+                    f"{request.url.path}"
+                )
+            request.headers["Authorization"] = f"Bearer {bearer_token}"
+            return
+
         headers = dict(request.headers)
         content_type = headers.get("Content-Type", "")
         body: str | None = None

--- a/server.py
+++ b/server.py
@@ -9,7 +9,7 @@ import urllib.parse
 import webbrowser
 from pathlib import Path
 
-import httpx
+import httpx2
 import requests
 from fastmcp import FastMCP
 from oauthlib.oauth1 import Client as OAuth1Client
@@ -25,6 +25,8 @@ HTTP_METHODS = {
     "head",
     "trace",
 }
+
+SERVER_VERSION = "2.0.0"
 
 LOGGER = logging.getLogger("xmcp.x_api")
 OAUTH_LOGGER = logging.getLogger("xmcp.oauth1")
@@ -338,9 +340,6 @@ def print_oauth1_header_probe(oauth1_client: OAuth1Client, base_url: str) -> Non
 def create_mcp() -> FastMCP:
     load_env()
     debug_enabled = setup_logging()
-    parser_flag = os.getenv("FASTMCP_EXPERIMENTAL_ENABLE_NEW_OPENAPI_PARSER")
-    if parser_flag is not None:
-        os.environ["FASTMCP_EXPERIMENTAL_ENABLE_NEW_OPENAPI_PARSER"] = parser_flag
 
     base_url = os.getenv("X_API_BASE_URL", "https://api.x.com")
     timeout = float(os.getenv("X_API_TIMEOUT", "30"))
@@ -355,7 +354,7 @@ def create_mcp() -> FastMCP:
     comma_params = collect_comma_params(filtered_spec)
     print_tool_list(filtered_spec)
 
-    async def normalize_query_params(request: httpx.Request) -> None:
+    async def normalize_query_params(request: httpx2.Request) -> None:
         if not comma_params:
             return
         params = list(request.url.params.multi_items())
@@ -395,7 +394,7 @@ def create_mcp() -> FastMCP:
 
     bearer_token = os.getenv("X_BEARER_TOKEN", "").strip()
 
-    async def sign_oauth1_request(request: httpx.Request) -> None:
+    async def sign_oauth1_request(request: httpx2.Request) -> None:
         request.headers["X-B3-Flags"] = b3_flags
 
         # App-Only endpoints: use Bearer, skip OAuth1 signing
@@ -420,7 +419,7 @@ def create_mcp() -> FastMCP:
             body=body,
             headers=headers,
         )
-        request.url = httpx.URL(signed_url)
+        request.url = httpx2.URL(signed_url)
         request.headers.update(signed_headers)
         if print_oauth_header:
             auth_header = signed_headers.get("Authorization")
@@ -429,12 +428,12 @@ def create_mcp() -> FastMCP:
             else:
                 print("OAuth1 Authorization header missing from signed request.")
 
-    async def log_request(request: httpx.Request) -> None:
+    async def log_request(request: httpx2.Request) -> None:
         if not debug_enabled:
             return
         LOGGER.info("X API request %s %s", request.method, request.url)
 
-    async def log_response(response: httpx.Response) -> None:
+    async def log_response(response: httpx2.Response) -> None:
         if not debug_enabled:
             return
         LOGGER.info(
@@ -453,7 +452,7 @@ def create_mcp() -> FastMCP:
                 text = text[:1000] + "...<truncated>"
             LOGGER.warning("X API error body: %s", text)
 
-    client = httpx.AsyncClient(
+    client = httpx2.AsyncClient(
         base_url=base_url,
         headers={},
         timeout=timeout,
@@ -462,10 +461,20 @@ def create_mcp() -> FastMCP:
             "response": [log_response],
         },
     )
+
+    # The tool set is derived from the OpenAPI spec once at startup and never
+    # changes for the life of the process, so MCP 2026-07-28 clients can cache
+    # tools/list and server/discover. MCP_CACHE_TTL=0 leaves the protocol
+    # default of ttlMs 0, which marks the result immediately stale.
+    cache_ttl = _get_env_int("MCP_CACHE_TTL", 300)
+
     return FastMCP.from_openapi(
         openapi_spec=filtered_spec,
         client=client,
         name="X API MCP",
+        version=SERVER_VERSION,
+        cache_ttl=cache_ttl or None,
+        cache_scope="private" if cache_ttl else None,
     )
 
 


### PR DESCRIPTION
Upgrade to FastMCP 4, the first release implementing the 2026-07-28 MCP revision. The server now answers server/discover and tools/list with no initialize handshake and no Mcp-Session-Id, and still serves handshake-era clients on 2025-11-25 from the same /mcp endpoint, so the xAI hosted MCP client used by test_grok_mcp.py keeps working unchanged.

- Pin fastmcp>=4.0.0b1 and swap httpx for httpx2, which FastMCP 4 uses. The X API client and all four event hooks (OAuth1 signing, comma-joined array query params, request/response logging) move across unchanged.
- Drop the FASTMCP_EXPERIMENTAL_ENABLE_NEW_OPENAPI_PARSER passthrough; that setting no longer exists in FastMCP 4.
- Advertise a server version and 2.0 cache hints on tools/list and server/discover. The tool set is derived from the OpenAPI spec once at startup and is immutable for the life of the process, so it is genuinely cacheable. Tunable via MCP_CACHE_TTL (default 300s).
- Document the protocol behavior, bump the stated Python floor to 3.10 to match FastMCP 4, and correct a stale README line about the spec being fetched from api.twitter.com.